### PR TITLE
Remove the redundant transform from active storage

### DIFF
--- a/activestorage/lib/active_storage/fixture_set.rb
+++ b/activestorage/lib/active_storage/fixture_set.rb
@@ -70,7 +70,7 @@ module ActiveStorage
       instance.assign_attributes(attributes)
       instance.upload_without_unfurling(io)
 
-      instance.attributes.transform_values { |value| value.is_a?(Hash) ? value.to_json : value }.compact.to_json
+      instance.attributes.compact.to_json
     end
   end
 end


### PR DESCRIPTION
### Summary

removed the transform_values, to optimize. it should be the same result
